### PR TITLE
Add validation for `#description` field in `#new-book` form

### DIFF
--- a/models/Book.js
+++ b/models/Book.js
@@ -8,7 +8,7 @@ class Book {
 		this.authorID = strToSlug(author);
 		this.genres = capitaliseArray(genres.replace(/,\s*$/, "").split(","));
 		this.publicationYear = publicationYear || null;
-		this.description = description || null;
+		this.description = description.slice(0, 280) || null;
 	}
 }
 

--- a/public/scripts/bookFormHandler.js
+++ b/public/scripts/bookFormHandler.js
@@ -14,7 +14,7 @@ const genresInput = document.querySelector("#genres");
 const yearInput = document.querySelector("#publication-year");
 const descriptionInput = document.querySelector("#description");
 
-const validationState = { title: null, author: null, genres: null, year: null };
+const validationState = { title: null, author: null, genres: null, year: null, description: null };
 
 const authors = await fetch("../authors/author-names")
 	.then(response => response.json())
@@ -155,15 +155,16 @@ const handleDescriptionInput = function () {
 	const descriptionMessage = document.querySelector("#description ~ .field-message");
 	const charCountElement = document.querySelector("#description ~ .char-count");
 	const charCount = descriptionInput.value.length;
+	const isDescriptionValid = charCount <= 280;
+
+	validationState.description = isDescriptionValid;
 
 	charCountElement.textContent = `${charCount}/280`;
-	charCountElement.classList.toggle("limit-exceeded", charCount > 280);
+	charCountElement.classList.toggle("limit-exceeded", !isDescriptionValid);
 
-	if (charCount > 280) {
-		descriptionMessage.textContent = "Character limit exceeded";
-	} else {
-		descriptionMessage.textContent = "";
-	}
+	descriptionMessage.textContent = isDescriptionValid ? "" : "Character limit exceeded";
+
+	return isDescriptionValid;
 };
 
 const handleSubmit = async function (e) {
@@ -174,6 +175,7 @@ const handleSubmit = async function (e) {
 		author: handleAuthorInput,
 		title: handleTitleInput,
 		genres: handleGenresInput,
+		description: handleDescriptionInput,
 	};
 
 	for (const [field, validator] of Object.entries(validators)) {

--- a/public/scripts/bookFormHandler.js
+++ b/public/scripts/bookFormHandler.js
@@ -12,6 +12,7 @@ const titleInput = document.querySelector("#title");
 const authorInput = document.querySelector("#author");
 const genresInput = document.querySelector("#genres");
 const yearInput = document.querySelector("#publication-year");
+const descriptionInput = document.querySelector("#description");
 
 const validationState = { title: null, author: null, genres: null, year: null };
 
@@ -42,7 +43,7 @@ const handleTitleInput = async function () {
 		return;
 	}
 
-	const titleMessage = document.querySelector("#title + .field-message");
+	const titleMessage = document.querySelector("#title ~ .field-message");
 	const book = titleInput.value;
 	const author = authorInput.value;
 
@@ -70,7 +71,7 @@ const handleAuthorInput = async function () {
 		return;
 	}
 
-	const authorMessage = document.querySelector("#author + .field-message");
+	const authorMessage = document.querySelector("#author ~ .field-message");
 	const author = authorInput.value;
 
 	if (!author) {
@@ -102,7 +103,7 @@ const handleGenresInput = async function () {
 		return;
 	}
 
-	const genresMessage = document.querySelector("#genres + .field-message");
+	const genresMessage = document.querySelector("#genres ~ .field-message");
 	const genresInputVal = genresInput.value;
 
 	if (!genresInputVal) {
@@ -134,7 +135,7 @@ const handleYearInput = function () {
 		return;
 	}
 
-	const yearMessage = document.querySelector("#publication-year + .field-message");
+	const yearMessage = document.querySelector("#publication-year ~ .field-message");
 	const year = yearInput.value;
 
 	const isYearValid = validateYear(Number(year));
@@ -148,6 +149,21 @@ const handleYearInput = function () {
 	}
 
 	return isYearValid;
+};
+
+const handleDescriptionInput = function () {
+	const descriptionMessage = document.querySelector("#description ~ .field-message");
+	const charCountElement = document.querySelector("#description ~ .char-count");
+	const charCount = descriptionInput.value.length;
+
+	charCountElement.textContent = `${charCount}/280`;
+	charCountElement.classList.toggle("limit-exceeded", charCount > 280);
+
+	if (charCount > 280) {
+		descriptionMessage.textContent = "Character limit exceeded";
+	} else {
+		descriptionMessage.textContent = "";
+	}
 };
 
 const handleSubmit = async function (e) {
@@ -191,4 +207,5 @@ inputs.forEach(({ element, blurHandler, validationKey }) => {
 	element.addEventListener("input", () => (validationState[validationKey] = null));
 });
 
+descriptionInput.addEventListener("input", handleDescriptionInput);
 form.addEventListener("submit", handleSubmit);

--- a/public/scripts/bookFormHandler.js
+++ b/public/scripts/bookFormHandler.js
@@ -193,7 +193,14 @@ const handleSubmit = async function (e) {
 	const isFormValid = Object.values(validationState).every(Boolean);
 
 	if (isFormValid) {
-		e.target.submit();
+		e.target.form.submit();
+	}
+};
+
+const submitOnEnter = async function (e) {
+	if (e.key === "Enter") {
+		e.preventDefault();
+		await handleSubmit(e);
 	}
 };
 
@@ -210,4 +217,6 @@ inputs.forEach(({ element, blurHandler, validationKey }) => {
 });
 
 descriptionInput.addEventListener("input", handleDescriptionInput);
+descriptionInput.addEventListener("keydown", submitOnEnter);
+
 form.addEventListener("submit", handleSubmit);

--- a/public/styles/index.css
+++ b/public/styles/index.css
@@ -57,3 +57,7 @@
 .selected {
 	opacity: 1;
 }
+
+.limit-exceeded {
+	font-weight: 700;
+}

--- a/views/books/newBook.ejs
+++ b/views/books/newBook.ejs
@@ -61,6 +61,7 @@
 					<label for="description">Blurb</label>
 					<textarea name="description" id="description" cols="40" rows="8"></textarea>
 					<span class="field-message"></span>
+					<span class="char-count">0/280</span>
 				</li>
 			</ul>
 			<button type="submit">Add book</button>

--- a/views/books/newBook.ejs
+++ b/views/books/newBook.ejs
@@ -59,7 +59,7 @@
 				</li>
 				<li>
 					<label for="description">Blurb</label>
-					<textarea name="description" id="description"></textarea>
+					<textarea name="description" id="description" cols="40" rows="8"></textarea>
 					<span class="field-message"></span>
 				</li>
 			</ul>


### PR DESCRIPTION
- Update `Book` constructor to `slice` `description` property at 280 character to ensure database limits are not exceeded.
- Add inline validation for `#description` element which displays the character limit and character count, and renders a message if the character limit is exceeded.
- Validate `#description` input on form submission
- Override behaviour of "Enter" key in `#description` to call `handleSubmit` instead of adding a line break.