### PR TITLE
Fix: resolve #11 `#new-book` form can only be submitted using the "Enter" key when focussed on the `#description` input

### DIFF
--- a/public/scripts/bookFormHandler.js
+++ b/public/scripts/bookFormHandler.js
@@ -193,7 +193,7 @@ const handleSubmit = async function (e) {
 	const isFormValid = Object.values(validationState).every(Boolean);
 
 	if (isFormValid) {
-		e.target.form.submit();
+		form.submit();
 	}
 };
 


### PR DESCRIPTION
Replace erroneous `e.target.form.submit` with `form.submit` in `handleSubmit()`function to prevent `TypeError` from being raised when not submitting with the "Enter" key while focussed on the `#description` field