### PR TITLE
Replace called to database in seed scripts with invocations of `insertBook()`, `insertAuthor()` and `insertGenre()`

### DIFF
--- a/db/queries/queryGenres.js
+++ b/db/queries/queryGenres.js
@@ -1,15 +1,14 @@
 const pool = require("../pool");
 
 exports.insertGenre = async function (newGenre) {
-	const { name, description } = newGenre;
-
-	const query = "INSERT INTO dim_genres (name, description) VALUES($1, $2)";
-
 	try {
-		await pool.query(query, [name, description]);
-	} catch (error) {
-		console.error(`Error inserting genre ${name}.`, error);
-		throw error;
+		await pool.query(
+			"INSERT INTO dim_genres (slug, name, description) VALUES ($1, $2, $3)",
+			Object.values(newGenre.toDbEntry())
+		);
+	} catch (err) {
+		console.error(`Error inserting genre ${newGenre}.`, err);
+		throw err;
 	}
 };
 

--- a/db/seed/scripts/insertAuthors.js
+++ b/db/seed/scripts/insertAuthors.js
@@ -1,8 +1,9 @@
 const path = require("path");
 const fs = require("fs").promises;
 const Author = require("../../../models/Author");
+const db = require("../../queries/index");
 
-async function insertAuthors(client) {
+async function insertAuthors() {
 	const filePath = path.join(__dirname, "../../data", "authors.json");
 	const authorsData = await fs.readFile(filePath, "utf8").then(data => JSON.parse(data));
 
@@ -10,12 +11,7 @@ async function insertAuthors(client) {
 		const author = new Author(entry);
 
 		try {
-			await author.fetchCountryID();
-
-			await client.query(
-				"INSERT INTO dim_authors (country_id, slug, first_name, last_name, birth_year, biography) VALUES ($1, $2, $3, $4, $5, $6)",
-				Object.values(author.toDbEntry())
-			);
+			await db.authors.insertAuthor(author);
 		} catch (err) {
 			console.error(`Error inserting author ${author}`, err);
 			continue;

--- a/db/seed/scripts/insertAuthors.js
+++ b/db/seed/scripts/insertAuthors.js
@@ -7,17 +7,22 @@ async function insertAuthors() {
 	const filePath = path.join(__dirname, "../../data", "authors.json");
 	const authorsData = await fs.readFile(filePath, "utf8").then(data => JSON.parse(data));
 
+	let successCount = 0;
+	let failedCount = 0;
+
 	for (const entry of authorsData) {
 		const author = new Author(entry);
 
 		try {
 			await db.authors.insertAuthor(author);
+			successCount += 1;
 		} catch (err) {
 			console.error(`Error inserting author ${author}`, err);
+			failedCount += 1;
 			continue;
 		}
 	}
-	console.log("Authors inserted successfully");
+	console.log(`${successCount} authors inserted successfully, ${failedCount} failures`);
 }
 
 module.exports = insertAuthors;

--- a/db/seed/scripts/insertBooks.js
+++ b/db/seed/scripts/insertBooks.js
@@ -1,8 +1,9 @@
 const path = require("path");
 const fs = require("fs").promises;
 const Book = require("../../../models/Book");
+const db = require("../../queries/index");
 
-async function insertBooks(client) {
+async function insertBooks() {
 	const filePath = path.join(__dirname, "../../data", "books.json");
 	const booksData = await fs.readFile(filePath, "utf8").then(data => JSON.parse(data));
 
@@ -13,13 +14,7 @@ async function insertBooks(client) {
 		const book = new Book(entry);
 
 		try {
-			await book.fetchAuthorID();
-
-			await client.query(
-				"INSERT INTO fact_books (author_id, slug, title, publication_year, is_fiction, description) VALUES ($1, $2, $3, $4, $5, $6)",
-				Object.values(book.toDbEntry())
-			);
-
+			await db.books.insertBook(book);
 			successCount += 1;
 		} catch (err) {
 			console.error(`Error inserting book ${book}.`, err);

--- a/db/seed/scripts/insertBooks.js
+++ b/db/seed/scripts/insertBooks.js
@@ -6,6 +6,9 @@ async function insertBooks(client) {
 	const filePath = path.join(__dirname, "../../data", "books.json");
 	const booksData = await fs.readFile(filePath, "utf8").then(data => JSON.parse(data));
 
+	let successCount = 0;
+	let failedCount = 0;
+
 	for (const entry of booksData) {
 		const book = new Book(entry);
 
@@ -16,12 +19,15 @@ async function insertBooks(client) {
 				"INSERT INTO fact_books (author_id, slug, title, publication_year, is_fiction, description) VALUES ($1, $2, $3, $4, $5, $6)",
 				Object.values(book.toDbEntry())
 			);
+
+			successCount += 1;
 		} catch (err) {
 			console.error(`Error inserting book ${book}.`, err);
+			failedCount += 1;
 			continue;
 		}
 	}
-	console.log("Books inserted successfully");
+	console.log(`${successCount} books inserted successfully, ${failedCount} failures`);
 }
 
 module.exports = insertBooks;

--- a/db/seed/scripts/insertCountries.js
+++ b/db/seed/scripts/insertCountries.js
@@ -7,14 +7,24 @@ async function insertCountries(client) {
 	const data = await fs.readFile(filePath, "utf8");
 	const countries = JSON.parse(data);
 
+	let successCount = 0;
+	let failedCount = 0;
+
 	for (const country of countries) {
 		country.slug = strToSlug(country.country);
-		await client.query(
-			"INSERT INTO dim_countries (slug, name, nationality, language) VALUES ($1, $2, $3, $4)",
-			[country.slug, country.country, country.nationality, country.language]
-		);
+		try {
+			await client.query(
+				"INSERT INTO dim_countries (slug, name, nationality, language) VALUES ($1, $2, $3, $4)",
+				[country.slug, country.country, country.nationality, country.language]
+			);
+			successCount += 1;
+		} catch (err) {
+			console.error(`Error inserting country ${country}`, err);
+			failedCount += 1;
+			continue;
+		}
 	}
-	console.log("Countries inserted successfully");
+	console.log(`${successCount} countries inserted successfully, ${failedCount} failures`);
 }
 
 module.exports = insertCountries;

--- a/db/seed/scripts/insertGenres.js
+++ b/db/seed/scripts/insertGenres.js
@@ -1,18 +1,16 @@
 const path = require("path");
 const fs = require("fs").promises;
 const Genre = require("../../../models/Genre");
+const db = require("../../queries/index");
 
-async function insertGenres(client) {
+async function insertGenres() {
 	const filePath = path.join(__dirname, "../../data", "genres.json");
 	const genresData = await fs.readFile(filePath, "utf8").then(data => JSON.parse(data));
 
 	for (const entry of genresData) {
 		const genre = new Genre(entry);
 		try {
-			await client.query(
-				"INSERT INTO dim_genres (slug, name, description) VALUES ($1, $2, $3)",
-				Object.values(genre.toDbEntry())
-			);
+			await db.genres.insertGenre(genre);
 		} catch (err) {
 			console.error(`Error inserting genre ${genre}`, err);
 			continue;

--- a/db/seed/scripts/insertGenres.js
+++ b/db/seed/scripts/insertGenres.js
@@ -7,16 +7,21 @@ async function insertGenres() {
 	const filePath = path.join(__dirname, "../../data", "genres.json");
 	const genresData = await fs.readFile(filePath, "utf8").then(data => JSON.parse(data));
 
+	let successCount = 0;
+	let failedCount = 0;
+
 	for (const entry of genresData) {
 		const genre = new Genre(entry);
 		try {
 			await db.genres.insertGenre(genre);
+			successCount += 1;
 		} catch (err) {
 			console.error(`Error inserting genre ${genre}`, err);
+			failedCount += 1;
 			continue;
 		}
 	}
-	console.log("Genres inserted successfully");
+	console.log(`${successCount} genres inserted successfully, ${failedCount} failures`);
 }
 
 module.exports = insertGenres;

--- a/db/seed/scripts/insertGenres.js
+++ b/db/seed/scripts/insertGenres.js
@@ -1,6 +1,5 @@
-const fs = require("fs").promises;
 const path = require("path");
-const { strToSlug } = require("../../../js/utils");
+const fs = require("fs").promises;
 const Genre = require("../../../models/Genre");
 
 async function insertGenres(client) {

--- a/db/seed/seed.js
+++ b/db/seed/seed.js
@@ -45,8 +45,6 @@ async function main() {
 		await insertAuthors(client);
 		await insertGenres(client);
 		await insertBooks(client);
-		await insertBookGenres(client);
-		await insertBookLanguages(client);
 	} catch (err) {
 		console.log("An error occurred during seeding", err);
 	} finally {


### PR DESCRIPTION
- Remove call to `insertBookGenres()`, as this is handled in `insertBook()`.
- Remove call to `insertBookLanguages()`, as this data is currently unused.