### PR TITLE
Fix: resolve #33 `strToNameCase()` incorrectly formats names if a par…

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -29,9 +29,11 @@ exports.strToSlug = function (str) {
 		.replace(/-+/g, "-");
 };
 
-exports.strToNameCase = function (str) {
-	const nobility = ["von", "van", "al", "bin", "bint", "ibn"];
-	const locative = ["de", "del", "da", "di", "dos", "della", "du", "vom", "zu"];
+exports.strToNameCase = function (str, options = {}) {
+	const { isSurname = false } = options;
+
+	const nobility = ["al", "bin", "bint", "ibn", "van", "von"];
+	const locative = ["da", "de", "del", "della", "di", "dos", "du", "vom", "zu"];
 	const articles = ["la", "las", "le", "los"];
 	const particles = [...nobility, ...locative, ...articles];
 
@@ -39,8 +41,10 @@ exports.strToNameCase = function (str) {
 	const nameCaseNames = names
 		.map((name, i) => {
 			const isParticle = particles.includes(name.toLowerCase());
+			const isCompoundName = names.length > 1;
+			const isNotLast = isCompoundName && isSurname && i < names.length - 1;
 
-			if (isParticle && names.length > 1) {
+			if (isParticle && isNotLast) {
 				return name.toLowerCase();
 			}
 

--- a/models/Author.js
+++ b/models/Author.js
@@ -7,7 +7,7 @@ class Author {
 	constructor({ firstName, lastName, birthYear, nationality, biography }) {
 		this.slug = strToSlug(`${firstName} ${lastName}`);
 		this.firstName = strToNameCase(firstName);
-		this.lastName = strToNameCase(lastName);
+		this.lastName = strToNameCase(lastName, { isSurname: true });
 		this.nationality = strToTitleCase(nationality);
 		this.birthYear = birthYear || null;
 		this.biography = biography || null;


### PR DESCRIPTION
…ticle is present as the last word of a surname

Add `options` argument to `strToNameCase()` where `isSurname` flag can be set Format particles in lowercase if `isSurname` is `true` and the name is not the last name of a compound surname Set `isSurname` flag to `true` when calling `strToNameCase` on `Author.lastName`