### PR TITLE
Use `chalk` library to improve seeding console messages

### DIFF
--- a/db/queries/queryAuthors.js
+++ b/db/queries/queryAuthors.js
@@ -1,4 +1,5 @@
 const pool = require("../pool");
+const logger = require("../../js/logger");
 
 exports.insertAuthor = async function (newAuthor) {
 	try {
@@ -12,7 +13,7 @@ exports.insertAuthor = async function (newAuthor) {
 			Object.values(newAuthor.toDbEntry())
 		);
 	} catch (err) {
-		console.error(`Error inserting author ${newAuthor}.`, err);
+		logger.error(`Error inserting author ${JSON.stringify(newAuthor, null, 2)}.`, err);
 		throw err;
 	}
 };

--- a/db/queries/queryBooks.js
+++ b/db/queries/queryBooks.js
@@ -1,4 +1,5 @@
 const pool = require("../pool");
+const logger = require("../../js/logger");
 
 exports.insertBook = async function (newBook) {
 	try {
@@ -29,7 +30,7 @@ exports.insertBook = async function (newBook) {
 		return bookID;
 	} catch (err) {
 		await pool.query("ROLLBACK");
-		console.error(`Error inserting book ${newBook}.`, err);
+		logger.error(`Error inserting book ${JSON.stringify(newBook, null, 2)}.`, err);
 		throw err;
 	}
 };

--- a/db/queries/queryGenres.js
+++ b/db/queries/queryGenres.js
@@ -1,4 +1,5 @@
 const pool = require("../pool");
+const logger = require("../../js/logger");
 
 exports.insertGenre = async function (newGenre) {
 	try {
@@ -7,7 +8,7 @@ exports.insertGenre = async function (newGenre) {
 			Object.values(newGenre.toDbEntry())
 		);
 	} catch (err) {
-		console.error(`Error inserting genre ${newGenre}.`, err);
+		logger.error(`Error inserting genre ${JSON.stringify(newGenre, null, 2)}.`, err);
 		throw err;
 	}
 };

--- a/db/seed/scripts/insertAuthors.js
+++ b/db/seed/scripts/insertAuthors.js
@@ -2,6 +2,7 @@ const path = require("path");
 const fs = require("fs").promises;
 const Author = require("../../../models/Author");
 const db = require("../../queries/index");
+const logger = require("../../../js/logger");
 
 async function insertAuthors() {
 	const filePath = path.join(__dirname, "../../data", "authors.json");
@@ -17,7 +18,6 @@ async function insertAuthors() {
 			await db.authors.insertAuthor(author);
 			successCount += 1;
 		} catch (err) {
-			console.error(`Error inserting author ${author}`, err);
 			failedCount += 1;
 			continue;
 		}

--- a/db/seed/scripts/insertAuthors.js
+++ b/db/seed/scripts/insertAuthors.js
@@ -22,7 +22,7 @@ async function insertAuthors() {
 			continue;
 		}
 	}
-	console.log(`${successCount} authors inserted successfully, ${failedCount} failures`);
+	console.log(`> ${successCount} authors inserted successfully (${failedCount} failures)`);
 }
 
 module.exports = insertAuthors;

--- a/db/seed/scripts/insertAuthors.js
+++ b/db/seed/scripts/insertAuthors.js
@@ -8,21 +8,25 @@ async function insertAuthors() {
 	const filePath = path.join(__dirname, "../../data", "authors.json");
 	const authorsData = await fs.readFile(filePath, "utf8").then(data => JSON.parse(data));
 
-	let successCount = 0;
-	let failedCount = 0;
+	const authorsFailed = [];
+	let authorsAddedCount = 0;
 
 	for (const entry of authorsData) {
 		const author = new Author(entry);
 
 		try {
 			await db.authors.insertAuthor(author);
-			successCount += 1;
+			authorsAddedCount += 1;
 		} catch (err) {
-			failedCount += 1;
+			authorsFailed.push(`${author.firstName} ${author.lastName}`);
 			continue;
 		}
 	}
-	console.log(`> ${successCount} authors inserted successfully (${failedCount} failures)`);
+	console.log(
+		`> ${authorsAddedCount} authors inserted successfully (${authorsFailed.length} failures)`
+	);
+
+	return { authorsAddedCount, authorsFailed };
 }
 
 module.exports = insertAuthors;

--- a/db/seed/scripts/insertBooks.js
+++ b/db/seed/scripts/insertBooks.js
@@ -17,7 +17,6 @@ async function insertBooks() {
 			await db.books.insertBook(book);
 			successCount += 1;
 		} catch (err) {
-			console.error(`Error inserting book ${book}.`, err);
 			failedCount += 1;
 			continue;
 		}

--- a/db/seed/scripts/insertBooks.js
+++ b/db/seed/scripts/insertBooks.js
@@ -7,21 +7,23 @@ async function insertBooks() {
 	const filePath = path.join(__dirname, "../../data", "books.json");
 	const booksData = await fs.readFile(filePath, "utf8").then(data => JSON.parse(data));
 
-	let successCount = 0;
-	let failedCount = 0;
+	const booksFailed = [];
+	let booksAddedCount = 0;
 
 	for (const entry of booksData) {
 		const book = new Book(entry);
 
 		try {
 			await db.books.insertBook(book);
-			successCount += 1;
+			booksAddedCount += 1;
 		} catch (err) {
-			failedCount += 1;
+			booksFailed.push(book.title);
 			continue;
 		}
 	}
-	console.log(`> ${successCount} books inserted successfully (${failedCount} failures)`);
+	console.log(`> ${booksAddedCount} books inserted successfully (${booksFailed.length} failures)`);
+
+	return { booksAddedCount, booksFailed };
 }
 
 module.exports = insertBooks;

--- a/db/seed/scripts/insertBooks.js
+++ b/db/seed/scripts/insertBooks.js
@@ -22,7 +22,7 @@ async function insertBooks() {
 			continue;
 		}
 	}
-	console.log(`${successCount} books inserted successfully, ${failedCount} failures`);
+	console.log(`> ${successCount} books inserted successfully (${failedCount} failures)`);
 }
 
 module.exports = insertBooks;

--- a/db/seed/scripts/insertCountries.js
+++ b/db/seed/scripts/insertCountries.js
@@ -8,8 +8,8 @@ async function insertCountries(client) {
 	const data = await fs.readFile(filePath, "utf8");
 	const countries = JSON.parse(data);
 
-	let successCount = 0;
-	let failedCount = 0;
+	const countriesFailed = [];
+	let countriesAddedCount = 0;
 
 	for (const country of countries) {
 		country.slug = strToSlug(country.country);
@@ -18,14 +18,18 @@ async function insertCountries(client) {
 				"INSERT INTO dim_countries (slug, name, nationality, language) VALUES ($1, $2, $3, $4)",
 				[country.slug, country.name, country.nationality, country.language]
 			);
-			successCount += 1;
+			countriesAddedCount += 1;
 		} catch (err) {
 			logger.error(`Error inserting country ${JSON.stringify(country, null, 2)}`, err);
-			failedCount += 1;
+			countriesFailed.push(country.name);
 			continue;
 		}
 	}
-	console.log(`> ${successCount} countries inserted successfully (${failedCount} failures)`);
+	console.log(
+		`> ${countriesAddedCount} countries inserted successfully (${countriesFailed.length} failures)`
+	);
+
+	return { countriesAddedCount, countriesFailed };
 }
 
 module.exports = insertCountries;

--- a/db/seed/scripts/insertCountries.js
+++ b/db/seed/scripts/insertCountries.js
@@ -16,11 +16,11 @@ async function insertCountries(client) {
 		try {
 			await client.query(
 				"INSERT INTO dim_countries (slug, name, nationality, language) VALUES ($1, $2, $3, $4)",
-				[country.slug, country.country, country.nationality, country.language]
+				[country.slug, country.name, country.nationality, country.language]
 			);
 			successCount += 1;
 		} catch (err) {
-			console.error(`Error inserting country ${country}`, err);
+			logger.error(`Error inserting country ${JSON.stringify(country, null, 2)}`, err);
 			failedCount += 1;
 			continue;
 		}

--- a/db/seed/scripts/insertCountries.js
+++ b/db/seed/scripts/insertCountries.js
@@ -1,5 +1,6 @@
 const fs = require("fs").promises;
 const path = require("path");
+const logger = require("../../../js/logger");
 const { strToSlug } = require("../../../js/utils");
 
 async function insertCountries(client) {
@@ -24,7 +25,7 @@ async function insertCountries(client) {
 			continue;
 		}
 	}
-	console.log(`${successCount} countries inserted successfully, ${failedCount} failures`);
+	console.log(`> ${successCount} countries inserted successfully (${failedCount} failures)`);
 }
 
 module.exports = insertCountries;

--- a/db/seed/scripts/insertGenres.js
+++ b/db/seed/scripts/insertGenres.js
@@ -8,20 +8,24 @@ async function insertGenres() {
 	const filePath = path.join(__dirname, "../../data", "genres.json");
 	const genresData = await fs.readFile(filePath, "utf8").then(data => JSON.parse(data));
 
-	let successCount = 0;
-	let failedCount = 0;
+	const genresFailed = [];
+	let genresAddedCount = 0;
 
 	for (const entry of genresData) {
 		const genre = new Genre(entry);
 		try {
 			await db.genres.insertGenre(genre);
-			successCount += 1;
+			genresAddedCount += 1;
 		} catch (err) {
-			failedCount += 1;
+			genresFailed.push(genre.name);
 			continue;
 		}
 	}
-	console.log(`> ${successCount} genres inserted successfully (${failedCount} failures)`);
+	console.log(
+		`> ${genresAddedCount} genres inserted successfully (${genresFailed.length} failures)`
+	);
+
+	return { genresAddedCount, genresFailed };
 }
 
 module.exports = insertGenres;

--- a/db/seed/scripts/insertGenres.js
+++ b/db/seed/scripts/insertGenres.js
@@ -2,6 +2,7 @@ const path = require("path");
 const fs = require("fs").promises;
 const Genre = require("../../../models/Genre");
 const db = require("../../queries/index");
+const logger = require("../../../js/logger");
 
 async function insertGenres() {
 	const filePath = path.join(__dirname, "../../data", "genres.json");
@@ -16,7 +17,6 @@ async function insertGenres() {
 			await db.genres.insertGenre(genre);
 			successCount += 1;
 		} catch (err) {
-			console.error(`Error inserting genre ${genre}`, err);
 			failedCount += 1;
 			continue;
 		}

--- a/db/seed/scripts/insertGenres.js
+++ b/db/seed/scripts/insertGenres.js
@@ -21,7 +21,7 @@ async function insertGenres() {
 			continue;
 		}
 	}
-	console.log(`${successCount} genres inserted successfully, ${failedCount} failures`);
+	console.log(`> ${successCount} genres inserted successfully (${failedCount} failures)`);
 }
 
 module.exports = insertGenres;

--- a/db/seed/seed.js
+++ b/db/seed/seed.js
@@ -3,6 +3,7 @@
 const { Client } = require("pg");
 const fs = require("fs").promises;
 const path = require("path");
+const chalk = require("chalk");
 const logger = require("../../js/logger");
 
 require("dotenv").config();
@@ -33,6 +34,11 @@ async function main() {
 		ssl: isProduction ? { rejectUnauthorized: false } : false,
 	});
 
+	let countriesAddedCount, countriesFailed;
+	let authorsAddedCount, authorsFailed;
+	let genresAddedCount, genresFailed;
+	let booksAddedCount, booksFailed;
+
 	try {
 		await client.connect();
 
@@ -41,14 +47,24 @@ async function main() {
 		logger.separator();
 		console.log("> Schema successfully created");
 
-		await insertCountries(client);
-		await insertAuthors(client);
-		await insertGenres(client);
-		await insertBooks(client);
+		({ countriesAddedCount, countriesFailed } = await insertCountries(client));
+		({ authorsAddedCount, authorsFailed } = await insertAuthors(client));
+		({ genresAddedCount, genresFailed } = await insertGenres(client));
+		({ booksAddedCount, booksFailed } = await insertBooks(client));
 	} catch (err) {
 		logger.error("An error occurred during seeding", err);
 	} finally {
 		await client.end();
+		logger.summary({
+			countriesAddedCount,
+			countriesFailed,
+			authorsAddedCount,
+			authorsFailed,
+			genresAddedCount,
+			genresFailed,
+			booksAddedCount,
+			booksFailed,
+		});
 		logger.info("Seeding complete!");
 		logger.separator();
 	}

--- a/db/seed/seed.js
+++ b/db/seed/seed.js
@@ -3,6 +3,7 @@
 const { Client } = require("pg");
 const fs = require("fs").promises;
 const path = require("path");
+const logger = require("../../js/logger");
 
 require("dotenv").config();
 
@@ -20,7 +21,7 @@ function getArgumentValue(flag, defaultValue) {
 }
 
 async function main() {
-	console.log("Seeding...");
+	logger.info("Seeding initialised...");
 
 	const user = getArgumentValue("--user", process.env.USER);
 	const password = getArgumentValue("--password", process.env.PASSWORD);
@@ -37,17 +38,19 @@ async function main() {
 
 		const schema = await fs.readFile(path.join(__dirname, "schema.sql"), "utf8");
 		await client.query(schema);
-		console.log("Schema created successfully");
+		logger.separator();
+		console.log("> Schema successfully created");
 
 		await insertCountries(client);
 		await insertAuthors(client);
 		await insertGenres(client);
 		await insertBooks(client);
 	} catch (err) {
-		console.log("An error occurred during seeding", err);
+		logger.error("An error occurred during seeding", err);
 	} finally {
 		await client.end();
-		console.log("Seeding complete");
+		logger.info("Seeding complete!");
+		logger.separator();
 	}
 }
 

--- a/js/logger.js
+++ b/js/logger.js
@@ -19,7 +19,20 @@ exports.error = function (message, err) {
 	}
 };
 
-exports.summary = function (message) {
+exports.summary = function (data) {
 	this.separator();
-	console.log(chalk.cyan("[SUMMARY]") + `\n> ${message}`);
+	console.log(chalk.blue("[SUMMARY]\n"));
+	printSummary("countries", data.countriesAddedCount, data.countriesFailed);
+	printSummary("authors", data.authorsAddedCount, data.authorsFailed);
+	printSummary("genres", data.genresAddedCount, data.genresFailed);
+	printSummary("books", data.booksAddedCount, data.booksFailed);
+};
+
+const printSummary = function (table, successCount, failed) {
+	console.log(table.toUpperCase());
+	console.log(chalk.bold(`├ inserted: ${chalk.green(successCount)}`));
+	console.log(chalk.bold(`└── failed: ${chalk.red(failed.length)}`));
+	if (failed.length > 0) {
+		console.log(chalk.red(`\t  - ${failed.join(`\n\t  - `)}`));
+	}
 };

--- a/js/logger.js
+++ b/js/logger.js
@@ -1,0 +1,25 @@
+const chalk = require("chalk");
+
+exports.separator = function () {
+	const width = process.stdout.columns || 80;
+	console.log("-".repeat(width));
+};
+
+exports.info = function (message) {
+	this.separator();
+	console.log(chalk.blue(`[INFO]  ${message}`));
+};
+
+exports.error = function (message, err) {
+	this.separator();
+	console.error(chalk.red(`[ERROR] ${message}`));
+
+	if (err) {
+		console.error("> ", err);
+	}
+};
+
+exports.summary = function (message) {
+	this.separator();
+	console.log(chalk.cyan("[SUMMARY]") + `\n> ${message}`);
+};

--- a/models/Author.js
+++ b/models/Author.js
@@ -1,4 +1,5 @@
 const db = require("../db/queries/index");
+const logger = require("../js/logger");
 const { strToSlug } = require("../js/utils");
 const { strToTitleCase } = require("../js/utils");
 const { strToNameCase } = require("../js/utils");
@@ -17,7 +18,10 @@ class Author {
 		try {
 			this.countryID = await db.countries.getCountryIDByNationality(this.nationality);
 		} catch (err) {
-			console.log(`Error fetching country_id for nationality ${this.nationality}.`, err);
+			logger.error(
+				`Error fetching country_id with nationality "${this.nationality} for author ${this.firstName} + ${this.lastName}".`,
+				err
+			);
 			throw err;
 		}
 	}

--- a/models/Book.js
+++ b/models/Book.js
@@ -1,4 +1,5 @@
 const db = require("../db/queries/index");
+const logger = require("../js/logger");
 const { strToSlug } = require("../js/utils");
 const { strToTitleCase } = require("../js/utils");
 const { capitaliseArray } = require("../js/utils");
@@ -22,7 +23,7 @@ class Book {
 		try {
 			this.authorID = await db.authors.getAuthorIDByName(this.author);
 		} catch (err) {
-			console.log(`Error fetching ID for author ${this.author}.`, err);
+			logger.error(`Error fetching ID for author ${this.author}.`, err);
 			throw err;
 		}
 	}


### PR DESCRIPTION
- Improve formatting of each stage of the seeding process.
- Add a `logger` module with core logging functions such as `info()` and `error()`.
- Avoid duplicate prints of errors that propagate through multiple `try... catch` blocks.
- Summarise successful and unsuccessful database entries and list entries caught in a `catch` block.