### PR TITLE
Prompt users with confirmation dialogues before submitting `DELETE` requests

### DIFF
--- a/public/scripts/dialogueController.js
+++ b/public/scripts/dialogueController.js
@@ -1,0 +1,15 @@
+const dialogueWrappers = document.querySelectorAll(".dialogue-wrapper");
+
+dialogueWrappers.forEach(wrapper => {
+	const dialogue = wrapper.querySelector("dialog");
+	const showButton = wrapper.querySelector("dialog + button");
+	const closeButton = wrapper.querySelector("dialog button");
+
+	showButton.addEventListener("click", () => {
+		dialogue.showModal();
+	});
+
+	closeButton.addEventListener("click", () => {
+		dialogue.close();
+	});
+});

--- a/public/styles/index.css
+++ b/public/styles/index.css
@@ -66,12 +66,16 @@
 	display: inline;
 }
 
-nav ul {
+ul {
+	padding-inline-start: 1rem;
+}
+
+nav > ul {
 	margin: 0;
 	padding-inline-start: 0;
 }
 
-nav ul li {
+nav > ul li {
 	display: inline;
 }
 

--- a/public/styles/index.css
+++ b/public/styles/index.css
@@ -62,7 +62,8 @@
 	font-weight: 700;
 }
 
-.method-override-wrapper {
+.method-override-wrapper,
+.dialog-wrapper {
 	display: inline;
 }
 

--- a/public/styles/index.css
+++ b/public/styles/index.css
@@ -67,6 +67,10 @@
 	display: inline;
 }
 
+.dialogue-actions {
+	text-align: right;
+}
+
 ul {
 	padding-inline-start: 1rem;
 }

--- a/views/authors/author.ejs
+++ b/views/authors/author.ejs
@@ -14,7 +14,7 @@
 				<h2><%= author.name %></h2>
 				<nav>
 					<button type="button" aria-label="Edit genre">Edit</button>
-					<div class="dialogue-wrapper" style="display: inline">
+					<div class="dialogue-wrapper">
 						<dialog>
 							<h3>Delete <%= author.name %>?</h3>
 							<p>This will also remove the following books by <%= author.name %>.</p>

--- a/views/authors/author.ejs
+++ b/views/authors/author.ejs
@@ -16,23 +16,29 @@
 					<button type="button" aria-label="Edit genre">Edit</button>
 					<div class="dialogue-wrapper">
 						<dialog>
-							<h3>Delete <%= author.name %>?</h3>
-							<p>This will also remove the following books by <%= author.name %>.</p>
-							<ul>
-								<% books.map((book) => { %>
-								<li>
-									<a href="/books/<%= book.id %>/<%= book.slug %>"><%= book.title %></a>
-								</li>
-								<% }) %>
-							</ul>
-							<button autofocus>Close</button>
-							<form
-								class="method-override-wrapper"
-								action="/authors/<%= author.id %>/<%= author.slug %>?_method=DELETE"
-								method="POST"
-							>
-								<button type="submit" aria-label="Delete author">Delete</button>
-							</form>
+							<header>
+								<h3>Delete <%= author.name %>?</h3>
+							</header>
+							<section>
+								<p>This will also remove the following books by <%= author.name %>.</p>
+								<ul>
+									<% books.map((book) => { %>
+									<li>
+										<a href="/books/<%= book.id %>/<%= book.slug %>"><%= book.title %></a>
+									</li>
+									<% }) %>
+								</ul>
+							</section>
+							<footer class="dialogue-actions">
+								<button autofocus>Close</button>
+								<form
+									class="method-override-wrapper"
+									action="/authors/<%= author.id %>/<%= author.slug %>?_method=DELETE"
+									method="POST"
+								>
+									<button type="submit" aria-label="Delete author">Delete</button>
+								</form>
+							</footer>
 						</dialog>
 						<button>Delete</button>
 					</div>

--- a/views/authors/author.ejs
+++ b/views/authors/author.ejs
@@ -12,15 +12,21 @@
 		<article>
 			<header>
 				<h2><%= author.name %></h2>
-				<nav>
-					<button type="button" aria-label="Edit genre">Edit</button>
+				<nav aria-label="Author actions">
+					<button type="button" aria-label="Edit author">Edit</button>
 					<div class="dialogue-wrapper">
-						<dialog>
+						<dialog
+							id="delete-author-dialog"
+							aria-labelledby="delete-author-title"
+							aria-describedby="delete-author-description"
+						>
 							<header>
-								<h3>Delete <%= author.name %>?</h3>
+								<h3 id="delete-author-title">Delete <%= author.name %>?</h3>
 							</header>
 							<section>
-								<p>This will also remove the following books by <%= author.name %>.</p>
+								<p id="delete-author-description">
+									This will also remove the following books by <%= author.name %>.
+								</p>
 								<ul>
 									<% books.map((book) => { %>
 									<li>
@@ -30,7 +36,7 @@
 								</ul>
 							</section>
 							<footer class="dialogue-actions">
-								<button autofocus>Close</button>
+								<button autofocus aria-label="Close dialog">Close</button>
 								<form
 									class="method-override-wrapper"
 									action="/authors/<%= author.id %>/<%= author.slug %>?_method=DELETE"
@@ -40,7 +46,7 @@
 								</form>
 							</footer>
 						</dialog>
-						<button>Delete</button>
+						<button aria-haspopup="dialog" aria-controls="delete-author-dialog">Delete</button>
 					</div>
 				</nav>
 			</header>

--- a/views/authors/author.ejs
+++ b/views/authors/author.ejs
@@ -5,6 +5,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Inventory | <%= author.name %></title>
 		<link rel="stylesheet" href="/styles/index.css" />
+		<script type="module" src="/scripts/dialogueController.js"></script>
 	</head>
 	<body>
 		<%- include("../partials/header", { backAnchor: true }) %>
@@ -13,13 +14,28 @@
 				<h2><%= author.name %></h2>
 				<nav>
 					<button type="button" aria-label="Edit genre">Edit</button>
-					<form
-						class="method-override-wrapper"
-						action="/authors/<%= author.id %>/<%= author.slug %>?_method=DELETE"
-						method="POST"
-					>
-						<button type="submit" aria-label="Delete author">Delete</button>
-					</form>
+					<div class="dialogue-wrapper" style="display: inline">
+						<dialog>
+							<h3>Delete <%= author.name %>?</h3>
+							<p>This will also remove the following books by <%= author.name %>.</p>
+							<ul>
+								<% books.map((book) => { %>
+								<li>
+									<a href="/books/<%= book.id %>/<%= book.slug %>"><%= book.title %></a>
+								</li>
+								<% }) %>
+							</ul>
+							<button autofocus>Close</button>
+							<form
+								class="method-override-wrapper"
+								action="/authors/<%= author.id %>/<%= author.slug %>?_method=DELETE"
+								method="POST"
+							>
+								<button type="submit" aria-label="Delete author">Delete</button>
+							</form>
+						</dialog>
+						<button>Delete</button>
+					</div>
 				</nav>
 			</header>
 			<p><%= author.biography %><</p>

--- a/views/books/book.ejs
+++ b/views/books/book.ejs
@@ -12,15 +12,22 @@
 		<article>
 			<header>
 				<h2><%= book.title %></h2>
-				<nav>
+				<nav aria-label="Book actions">
 					<button type="button" aria-label="Edit book">Edit</button>
 					<div class="dialogue-wrapper">
-						<dialog>
+						<dialog
+							id="delete-book-dialog"
+							aria-labelledby="delete-book-title"
+							aria-describedby="delete-book-description"
+						>
 							<header>
-								<h3>Delete <%= book.title %>?</h3>
+								<h3 id="delete-book-title">Delete <%= book.title %>?</h3>
 							</header>
+							<section>
+								<p id="delete-book-description">This will permanently delete <%= book.title %>.</p>
+							</section>
 							<footer class="dialogue-actions">
-								<button autofocus>Close</button>
+								<button autofocus aria-label="Close dialog">Close</button>
 								<form
 									class="method-override-wrapper"
 									action="/books/<%= book.id %>/<%= book.slug %>?_method=DELETE"
@@ -30,7 +37,7 @@
 								</form>
 							</footer>
 						</dialog>
-						<button>Delete</button>
+						<button aria-haspopup="dialog" aria-controls="delete-book-dialog">Delete</button>
 					</div>
 				</nav>
 			</header>

--- a/views/books/book.ejs
+++ b/views/books/book.ejs
@@ -16,15 +16,19 @@
 					<button type="button" aria-label="Edit book">Edit</button>
 					<div class="dialogue-wrapper">
 						<dialog>
-							<h3>Delete <%= book.title %>?</h3>
-							<button autofocus>Close</button>
-							<form
-								class="method-override-wrapper"
-								action="/books/<%= book.id %>/<%= book.slug %>?_method=DELETE"
-								method="POST"
-							>
-								<button type="submit" aria-label="Delete book">Delete</button>
-							</form>
+							<header>
+								<h3>Delete <%= book.title %>?</h3>
+							</header>
+							<footer class="dialogue-actions">
+								<button autofocus>Close</button>
+								<form
+									class="method-override-wrapper"
+									action="/books/<%= book.id %>/<%= book.slug %>?_method=DELETE"
+									method="POST"
+								>
+									<button type="submit" aria-label="Delete book">Delete</button>
+								</form>
+							</footer>
 						</dialog>
 						<button>Delete</button>
 					</div>

--- a/views/books/book.ejs
+++ b/views/books/book.ejs
@@ -14,7 +14,7 @@
 				<h2><%= book.title %></h2>
 				<nav>
 					<button type="button" aria-label="Edit book">Edit</button>
-					<div class="dialogue-wrapper" style="display: inline">
+					<div class="dialogue-wrapper">
 						<dialog>
 							<h3>Delete <%= book.title %>?</h3>
 							<button autofocus>Close</button>

--- a/views/books/book.ejs
+++ b/views/books/book.ejs
@@ -5,6 +5,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Inventory | <%= book.title %></title>
 		<link rel="stylesheet" href="/styles/index.css" />
+		<script type="module" src="/scripts/dialogueController.js"></script>
 	</head>
 	<body>
 		<%- include("../partials/header", { backAnchor: true }) %>
@@ -13,13 +14,20 @@
 				<h2><%= book.title %></h2>
 				<nav>
 					<button type="button" aria-label="Edit book">Edit</button>
-					<form
-						class="method-override-wrapper"
-						action="/books/<%= book.id %>/<%= book.slug %>?_method=DELETE"
-						method="POST"
-					>
-						<button type="submit" aria-label="Delete book">Delete</button>
-					</form>
+					<div class="dialogue-wrapper" style="display: inline">
+						<dialog>
+							<h3>Delete <%= book.title %>?</h3>
+							<button autofocus>Close</button>
+							<form
+								class="method-override-wrapper"
+								action="/books/<%= book.id %>/<%= book.slug %>?_method=DELETE"
+								method="POST"
+							>
+								<button type="submit" aria-label="Delete book">Delete</button>
+							</form>
+						</dialog>
+						<button>Delete</button>
+					</div>
 				</nav>
 			</header>
 			<dl>

--- a/views/genres/genre.ejs
+++ b/views/genres/genre.ejs
@@ -16,16 +16,22 @@
 					<button type="button" aria-label="Edit genre">Edit</button>
 					<div class="dialogue-wrapper">
 						<dialog>
-							<h3>Delete <%= genre.name %>?</h3>
-							<p>This will remove the <%= genre.name %> genre from <%= books.length %> books.</p>
-							<button autofocus>Close</button>
-							<form
-								class="method-override-wrapper"
-								action="/genres/<%= genre.id %>/<%= genre.slug %>?_method=DELETE"
-								method="POST"
-							>
-								<button type="submit" aria-label="Delete genre">Delete</button>
-							</form>
+							<header>
+								<h3>Delete <%= genre.name %>?</h3>
+							</header>
+							<section>
+								<p>This will remove the <%= genre.name %> genre from <%= books.length %> books.</p>
+							</section>
+							<footer class="dialogue-actions">
+								<button autofocus>Close</button>
+								<form
+									class="method-override-wrapper"
+									action="/genres/<%= genre.id %>/<%= genre.slug %>?_method=DELETE"
+									method="POST"
+								>
+									<button type="submit" aria-label="Delete genre">Delete</button>
+								</form>
+							</footer>
 						</dialog>
 						<button>Delete</button>
 					</div>

--- a/views/genres/genre.ejs
+++ b/views/genres/genre.ejs
@@ -5,6 +5,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Inventory | <%= genre.name %></title>
 		<link rel="stylesheet" href="/styles/index.css" />
+		<script type="module" src="/scripts/dialogueController.js"></script>
 	</head>
 	<body>
 		<%- include("../partials/header", { backAnchor: true }) %>
@@ -13,13 +14,21 @@
 				<h2><%= genre.name %></h2>
 				<nav>
 					<button type="button" aria-label="Edit genre">Edit</button>
-					<form
-						class="method-override-wrapper"
-						action="/genres/<%= genre.id %>/<%= genre.slug %>?_method=DELETE"
-						method="POST"
-					>
-						<button type="submit" aria-label="Delete genre">Delete</button>
-					</form>
+					<div class="dialogue-wrapper" style="display: inline">
+						<dialog>
+							<h3>Delete <%= genre.name %>?</h3>
+							<p>This will remove the <%= genre.name %> genre from <%= books.length %> books.</p>
+							<button autofocus>Close</button>
+							<form
+								class="method-override-wrapper"
+								action="/genres/<%= genre.id %>/<%= genre.slug %>?_method=DELETE"
+								method="POST"
+							>
+								<button type="submit" aria-label="Delete genre">Delete</button>
+							</form>
+						</dialog>
+						<button>Delete</button>
+					</div>
 				</nav>
 			</header>
 			<p><%= genre.description %></p>

--- a/views/genres/genre.ejs
+++ b/views/genres/genre.ejs
@@ -12,18 +12,24 @@
 		<article>
 			<header>
 				<h2><%= genre.name %></h2>
-				<nav>
+				<nav aria-label="Genre actions">
 					<button type="button" aria-label="Edit genre">Edit</button>
 					<div class="dialogue-wrapper">
-						<dialog>
+						<dialog
+							id="delete-genre-dialog"
+							aria-labelledby="delete-genre-title"
+							aria-describedby="delete-genre-description"
+						>
 							<header>
-								<h3>Delete <%= genre.name %>?</h3>
+								<h3 id="delete-genre-title">Delete <%= genre.name %>?</h3>
 							</header>
 							<section>
-								<p>This will remove the <%= genre.name %> genre from <%= books.length %> books.</p>
+								<p id="delete-genre-description">
+									This will remove the <%= genre.name %> genre from <%= books.length %> books.
+								</p>
 							</section>
 							<footer class="dialogue-actions">
-								<button autofocus>Close</button>
+								<button autofocus aria-label="Close dialog">Close</button>
 								<form
 									class="method-override-wrapper"
 									action="/genres/<%= genre.id %>/<%= genre.slug %>?_method=DELETE"
@@ -33,7 +39,7 @@
 								</form>
 							</footer>
 						</dialog>
-						<button>Delete</button>
+						<button aria-haspopup="dialog" aria-controls="delete-genre-dialog">Delete</button>
 					</div>
 				</nav>
 			</header>

--- a/views/genres/genre.ejs
+++ b/views/genres/genre.ejs
@@ -14,7 +14,7 @@
 				<h2><%= genre.name %></h2>
 				<nav>
 					<button type="button" aria-label="Edit genre">Edit</button>
-					<div class="dialogue-wrapper" style="display: inline">
+					<div class="dialogue-wrapper">
 						<dialog>
 							<h3>Delete <%= genre.name %>?</h3>
 							<p>This will remove the <%= genre.name %> genre from <%= books.length %> books.</p>


### PR DESCRIPTION
- Add delete confirmation dialogues for books, authors and genres.
- Show the number of books affected by deleting a genre.
- List the books that will be also deleted when deleting an author.