### PR TITLE
Fix issue that allowed inputs to violate `VARCHAR` database constraint

### DIFF
--- a/public/scripts/form-handlers/editBookFormHandler.js
+++ b/public/scripts/form-handlers/editBookFormHandler.js
@@ -38,13 +38,14 @@ const authorInput = document.querySelector("#author");
 const genresInput = document.querySelector("#genres");
 const yearInput = document.querySelector("#publication-year");
 const descriptionInput = document.querySelector("#description");
+const currentTitle = document.querySelector("#book-title").textContent;
 
 const validationState = { title: null, author: null, genres: null, year: null, description: null };
 
 const validators = {
 	year: () => validateYear(yearInput),
 	author: async () => await validateAuthor(authorInput),
-	title: async () => await validateTitle(titleInput, authorInput),
+	title: async () => await validateTitle(titleInput, authorInput, currentTitle),
 	genres: async () => await validateGenres(genresInput),
 	description: () => validateTextarea(descriptionInput),
 };

--- a/public/scripts/form-handlers/input-handlers/validateFieldLength.js
+++ b/public/scripts/form-handlers/input-handlers/validateFieldLength.js
@@ -1,0 +1,23 @@
+const validateFieldLength = function (input, { maxLength, minLength = 0 }) {
+	const inputMessage = document.querySelector(`#${input.id} ~ .field-message`);
+
+	if (!input.value) {
+		inputMessage.textContent = "";
+		return false;
+	}
+
+	const isTooLong = input.value.length > maxLength;
+	const isTooShort = input.value.length < minLength;
+
+	if (isTooLong) {
+		inputMessage.textContent = `Please enter a value of ${maxLength} or fewer characters.`;
+	} else if (isTooShort) {
+		inputMessage.textContent = `Please enter a value of ${minLength} or more characters.`;
+	} else {
+		inputMessage.textContent = "";
+	}
+
+	return !isTooLong && !isTooShort;
+};
+
+export default validateFieldLength;

--- a/public/scripts/form-handlers/input-handlers/validateGenre.js
+++ b/public/scripts/form-handlers/input-handlers/validateGenre.js
@@ -1,8 +1,14 @@
+import validateFieldLength from "./validateFieldLength.js";
 import { checkGenreExists } from "../../validateInputs.js";
 import { strToTitleCase } from "../../utils.js";
 
 const validateGenre = async function (genreInput, currentName = null) {
 	const genreMessage = document.querySelector(`#${genreInput.id} ~ .field-message`);
+	const isTooLong = !validateFieldLength(genreInput, { maxLength: 32 });
+
+	if (isTooLong) {
+		return;
+	}
 
 	if (!genreInput.value) {
 		genreMessage.textContent = "";

--- a/public/scripts/form-handlers/input-handlers/validateName.js
+++ b/public/scripts/form-handlers/input-handlers/validateName.js
@@ -1,8 +1,15 @@
+import validateFieldLength from "./validateFieldLength.js";
 import { checkAuthorExists } from "../../validateInputs.js";
 import { strToNameCase } from "../../utils.js";
 
 const validateName = async function (firstNameInput, lastNameInput, currentName = null) {
-	const nameMessage = document.querySelector(`#${firstNameInput.id} ~ .field-message`);
+	const nameMessage = document.querySelector(`#${firstNameInput.id} ~ .field-message:last-child`);
+	const firstNameTooLong = !validateFieldLength(firstNameInput, { maxLength: 32 });
+	const lastNameTooLong = !validateFieldLength(lastNameInput, { maxLength: 32 });
+
+	if (firstNameTooLong || lastNameTooLong) {
+		return;
+	}
 
 	if (!firstNameInput.value || !lastNameInput.value) {
 		nameMessage.textContent = "";

--- a/public/scripts/form-handlers/input-handlers/validateTitle.js
+++ b/public/scripts/form-handlers/input-handlers/validateTitle.js
@@ -1,9 +1,15 @@
+import validateFieldLength from "./validateFieldLength.js";
 import { checkBookByAuthorExists } from "../../validateInputs.js";
 import { strToNameCase } from "../../utils.js";
 import { strToTitleCase } from "../../utils.js";
 
 const validateTitle = async function (titleInput, authorInput, currentTitle = null) {
 	const titleMessage = document.querySelector(`#${titleInput.id} ~ .field-message`);
+	const isTooLong = !validateFieldLength(titleInput, { maxLength: 64 });
+
+	if (isTooLong) {
+		return;
+	}
 
 	if (!authorInput.value) {
 		titleMessage.textContent = "";

--- a/public/scripts/form-handlers/newBookFormHandler.js
+++ b/public/scripts/form-handlers/newBookFormHandler.js
@@ -38,7 +38,6 @@ const authorInput = document.querySelector("#author");
 const genresInput = document.querySelector("#genres");
 const yearInput = document.querySelector("#publication-year");
 const descriptionInput = document.querySelector("#description");
-const bookTitle = document.querySelector("#title");
 
 const validationState = { title: null, author: null, genres: null, year: null, description: null };
 

--- a/views/authors/author.ejs
+++ b/views/authors/author.ejs
@@ -32,6 +32,7 @@
                   <div class="field">
                     <label for="first-name">First name:</label>
                     <input value="<%= author.first_name %>" type="text" name="firstName" id="first-name" required />
+                    <span class="field-message"></span>
                     <label style="margin-top: 1rem" for="last-name">Surname</label>
                     <input value="<%= author.last_name %>" type="text" name="lastName" id="last-name" required />
                     <span class="field-message"></span>

--- a/views/authors/newAuthor.ejs
+++ b/views/authors/newAuthor.ejs
@@ -14,6 +14,7 @@
 			<div class="field">
 				<label for="first-name">First name</label>
 				<input type="text" name="firstName" id="first-name" required />
+				<span class="field-message"></span>
 				<label style="margin-top: 1rem" for="last-name">Surname</label>
 				<input type="text" name="lastName" id="last-name" required />
 				<span class="field-message"></span>

--- a/views/books/book.ejs
+++ b/views/books/book.ejs
@@ -12,7 +12,7 @@
 		<%- include("../partials/header", { backAnchor: true }) %>
 		<article>
 			<header>
-				<h2 id="title"><%= book.title %></h2>
+				<h2 id="book-title"><%= book.title %></h2>
 				<nav aria-label="Book actions">
 					<div class="dialogue-wrapper">
 						<dialog
@@ -149,7 +149,7 @@
 					</dd>
 				</div>
 			</dl>
-			<p><%= book.blurb %></p>
+      <p><%= book.blurb %></p>
 		</article>
 		<hr />
     <section>


### PR DESCRIPTION
- Create `validateFieldLength()`, which checks the length of an input is within a minimum and maximum length.
- `validateFieldLength()` returns a boolean and updates the `.field-message` of the input.
- Check the length of inputs before attempting to update database.
- Fix an issue where validation on `#title` input was prevented by a duplicate ID in `/:book` route.