### PR TITLE
Fix: override default `background-color` for `.nav-link` elements

### DIFF
--- a/public/styles/header.css
+++ b/public/styles/header.css
@@ -132,6 +132,8 @@ nav ul {
 	font-size: inherit;
 	line-height: inherit;
 	cursor: pointer;
+
+	background-color: transparent;
 }
 
 .nav-icon {


### PR DESCRIPTION
Resolves #77