### PR TITLE
Fix: resolve issue where global button styles were applied to `#back-anchor` element

### DIFF
--- a/public/sass/globals/_button.scss
+++ b/public/sass/globals/_button.scss
@@ -1,6 +1,6 @@
 @use "../util" as u;
 
-button {
+.btn {
 	border: solid 1px var(--cl-background-shade-3);
 	border-radius: var(--br-mid);
 	padding: 0.75rem 1.25rem;

--- a/public/sass/main.css
+++ b/public/sass/main.css
@@ -124,7 +124,7 @@ h2.small {
   font-size: 1.25rem;
 }
 
-button {
+.btn {
   border: solid 1px var(--cl-background-shade-3);
   border-radius: var(--br-mid);
   padding: 0.75rem 1.25rem;
@@ -136,7 +136,7 @@ button {
   background-color: var(--cl-background-shade-2);
   transition: 800ms;
 }
-button:hover, button:focus-visible {
+.btn:hover, .btn:focus-visible {
   outline: none;
   border: solid 1px var(--cl-emphasis);
   color: var(--cl-emphasis);

--- a/views/authors/author.ejs
+++ b/views/authors/author.ejs
@@ -148,21 +148,23 @@
 											</form>
 										</section>
 										<footer class="dialogue__actions">
-											<button autofocus class="form__button" aria-label="Close dialog">
+											<button autofocus aria-label="Close dialog" class="form__button btn">
 												Close
 											</button>
 											<button
-												class="form__button form__button--submit"
 												form="edit-author"
 												type="submit"
 												aria-label="Save author edits"
+												class="form__button form__button--submit btn"
 											>
 												Save
 											</button>
 										</footer>
 									</div>
 								</dialog>
-								<button aria-haspopup="dialog" aria-controls="edit-author-dialog">Edit</button>
+								<button aria-haspopup="dialog" aria-controls="edit-author-dialog" class="btn">
+									Edit
+								</button>
 							</div>
 							<div class="dialogue-wrapper">
 								<dialog
@@ -190,7 +192,7 @@
 											</ul>
 										</section>
 										<footer class="dialogue__actions">
-											<button autofocus class="form__button" aria-label="Close dialog">
+											<button autofocus aria-label="Close dialog" class="form__button btn">
 												Close
 											</button>
 											<form
@@ -200,8 +202,8 @@
 											>
 												<button
 													type="submit"
-													class="form__button form__button--delete"
 													aria-label="Delete author"
+													class="form__button form__button--delete btn"
 												>
 													Delete
 												</button>
@@ -209,7 +211,9 @@
 										</footer>
 									</div>
 								</dialog>
-								<button aria-haspopup="dialog" aria-controls="delete-author-dialog">Delete</button>
+								<button aria-haspopup="dialog" aria-controls="delete-author-dialog" class="btn">
+									Delete
+								</button>
 							</div>
 						</nav>
 					</header>

--- a/views/authors/newAuthor.ejs
+++ b/views/authors/newAuthor.ejs
@@ -93,7 +93,7 @@
 							<span class="form__field-message-content"></span>
 						</div>
 					</div>
-					<button type="submit" class="form__button form__button--submit">Add author</button>
+					<button type="submit" class="form__button form__button--submit btn">Add author</button>
 				</form>
 			</main>
 		</div>

--- a/views/books/book.ejs
+++ b/views/books/book.ejs
@@ -145,21 +145,23 @@
 											</form>
 										</section>
 										<footer class="dialogue__actions">
-											<button autofocus class="form__button" aria-label="Close dialog">
+											<button autofocus aria-label="Close dialog" class="form__button btn">
 												Close
 											</button>
 											<button
-												class="form__button form__button--submit"
 												form="edit-book"
 												type="submit"
 												aria-label="Save changes"
+												class="form__button form__button--submit btn"
 											>
 												Save changes
 											</button>
 										</footer>
 									</div>
 								</dialog>
-								<button aria-haspopup="dialog" aria-controls="edit-book-dialog">Edit</button>
+								<button aria-haspopup="dialog" aria-controls="edit-book-dialog" class="btn">
+									Edit
+								</button>
 							</div>
 							<div class="dialogue-wrapper">
 								<dialog
@@ -180,7 +182,7 @@
 											</p>
 										</section>
 										<footer class="dialogue__actions">
-											<button autofocus class="form__button" aria-label="Close dialog">
+											<button autofocus aria-label="Close dialog" class="form__button btn">
 												Close
 											</button>
 											<form
@@ -190,8 +192,8 @@
 											>
 												<button
 													type="submit"
-													class="form__button form__button--delete"
 													aria-label="Delete book"
+													class="form__button form__button--delete btn"
 												>
 													Delete
 												</button>
@@ -199,7 +201,9 @@
 										</footer>
 									</div>
 								</dialog>
-								<button aria-haspopup="dialog" aria-controls="delete-book-dialog">Delete</button>
+								<button aria-haspopup="dialog" aria-controls="delete-book-dialog" class="btn">
+									Delete
+								</button>
 							</div>
 						</nav>
 					</header>

--- a/views/books/newBook.ejs
+++ b/views/books/newBook.ejs
@@ -112,7 +112,7 @@
 							<span class="form__field-message-content"></span>
 						</div>
 					</div>
-					<button type="submit" class="form__button form__button--submit">Add book</button>
+					<button type="submit" class="form__button form__button--submit btn">Add book</button>
 				</form>
 			</main>
 		</div>

--- a/views/genres/genre.ejs
+++ b/views/genres/genre.ejs
@@ -76,21 +76,23 @@
 											</form>
 										</section>
 										<footer class="dialogue__actions">
-											<button autofocus class="form__button" aria-label="Close dialog">
+											<button autofocus aria-label="Close dialog" class="form__button btn">
 												Close
 											</button>
 											<button
-												class="form__button form__button--submit"
 												form="edit-genre"
 												type="submit"
 												aria-label="Save changes"
+												class="form__button form__button--submit btn"
 											>
 												Save changes
 											</button>
 										</footer>
 									</div>
 								</dialog>
-								<button aria-haspopup="dialog" aria-controls="edit-genre-dialog">Edit</button>
+								<button aria-haspopup="dialog" aria-controls="edit-genre-dialog" class="btn">
+									Edit
+								</button>
 							</div>
 							<div class="dialogue-wrapper">
 								<dialog
@@ -111,7 +113,7 @@
 											</p>
 										</section>
 										<footer class="dialogue__actions">
-											<button autofocus class="form__button" aria-label="Close dialog">
+											<button autofocus aria-label="Close dialog" class="form__button btn">
 												Close
 											</button>
 											<form
@@ -121,8 +123,8 @@
 											>
 												<button
 													type="submit"
-													class="form__button form__button--delete"
 													aria-label="Delete genre"
+													class="form__button form__button--delete btn"
 												>
 													Delete
 												</button>
@@ -130,7 +132,9 @@
 										</footer>
 									</div>
 								</dialog>
-								<button aria-haspopup="dialog" aria-controls="delete-genre-dialog">Delete</button>
+								<button aria-haspopup="dialog" aria-controls="delete-genre-dialog" class="btn">
+									Delete
+								</button>
 							</div>
 						</nav>
 					</header>

--- a/views/genres/newGenre.ejs
+++ b/views/genres/newGenre.ejs
@@ -43,7 +43,7 @@
 							<span class="form__field-message-content"></span>
 						</div>
 					</div>
-					<button type="submit" class="form__button form__button--submit">Add genre</button>
+					<button type="submit" class="form__button form__button--submit btn">Add genre</button>
 				</form>
 			</main>
 		</div>


### PR DESCRIPTION
- Only apply global button styles to `.btn` class.
- Give all `<button>` elements the `.btn` class, apart from `#back-anchor`. Resolves #92